### PR TITLE
fix repository typo and add repository name in the input field

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -82,7 +82,7 @@ class Container extends Component {
         <div className='container'>
           <GithubCorner href="https://github.com/arshadkazmi42/gh-rhof"/>
           <Heading className='heading'>
-            Generate Github Respository Hall of Fame
+            Generate Github Repository Hall of Fame
           </Heading>
           <PopupDialog
               showPopup={showPopup} onClose={this.handlePopupClose}
@@ -90,7 +90,7 @@ class Container extends Component {
           />
           <Input className='input' required error={showPopup} name='Username' defaultValue=''
                  onChange={this.handleOnChange}/>
-          <Input className='input' required error={showPopup} name='Repository' defaultValue=''
+          <Input className='input' required error={showPopup} name='Repository Name' defaultValue=''
                  onChange={this.handleOnChange}/>
           <ButtonPrimary className='button' onClick={this.handleOnSubmit}>
             Get Contributors


### PR DESCRIPTION
- fixed typo in repository spelling 
- Repository in the input is not very clear, initially, I entered repository url 
To make things clear include Repository Name in input 

<img width="722" alt="image" src="https://user-images.githubusercontent.com/41536903/194410930-a0b25ec7-7550-45b5-b5c0-bc4b1910915c.png">
